### PR TITLE
Set up CI template

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,20 +11,20 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: set up JDK 11
+    - name: set up JDK 21
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '21'
         distribution: 'temurin'
         cache: gradle
 
     # Navigate to the Android app directory
-    - name: Change to Android App directory
-      run: cd OOPs-I-Pushed-To-Main/src/OOPsIPushedToMain/
-
     - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-    - name: Build with Gradle
-      run: ./gradlew build
-    - name: Run Unit Tests
-      run: ./gradlew test --tests "com.oopsipushedtomain.FirebaseAccessUnitTest"
+      run: cd src/OOPsIPushedToMain/ && chmod +x gradlew
+    # - name: Build with Gradle
+    #   run: cd src/OOPsIPushedToMain/ && ./gradlew build
+    - name: Instrumentation Tests
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: 29
+        script: cd src/OOPsIPushedToMain/ && ./gradlew connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.oopsipushedtomain.FirebaseAccessUnitTest

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,7 +23,7 @@ jobs:
       run: cd src/OOPsIPushedToMain/ && chmod +x gradlew
     # - name: Build with Gradle
     #   run: cd src/OOPsIPushedToMain/ && ./gradlew build
-    - name: Instrumentation Tests
+    - name: Test Firebase Access
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 29

--- a/src/OOPsIPushedToMain/app/build.gradle.kts
+++ b/src/OOPsIPushedToMain/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         release {
             isMinifyEnabled = false
             proguardFiles(
-                    getDefaultProguardFile("proguard-android-optimize.txt"),
-                    "proguard-rules.pro"
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
             )
         }
     }
@@ -45,12 +45,12 @@ dependencies {
 
 //    implementation(files("C:/Users/matte/AppData/Local/Android/Sdk/platforms/android-34/android.jar"))
     implementation(libs.fragment.testing)
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.ext.junit)
-    androidTestImplementation(libs.espresso.core)
-    androidTestImplementation("androidx.test:core")
-    debugImplementation("androidx.fragment:fragment-testing:1.4.0")
-    androidTestImplementation("androidx.test.espresso:espresso-intents:3.4.0")
+//    testImplementation(libs.junit)
+//    androidTestImplementation(libs.ext.junit)
+//    androidTestImplementation(libs.espresso.core)
+//    androidTestImplementation("androidx.test:core")
+//    debugImplementation("androidx.fragment:fragment-testing:1.4.0")
+//    androidTestImplementation("androidx.test.espresso:espresso-intents:3.4.0")
 
     // Import the Firebase BoM
     implementation(platform("com.google.firebase:firebase-bom:32.7.3"))
@@ -65,4 +65,10 @@ dependencies {
 
     // Mockito for testing
     androidTestImplementation("org.mockito:mockito-core:4.0.0")
+
+    // Testing dependancies
+    androidTestImplementation(libs.ext.junit)
+    androidTestImplementation(libs.espresso.core)
+    androidTestImplementation(libs.androidx.espresso.intents)
+
 }

--- a/src/OOPsIPushedToMain/gradle/libs.versions.toml
+++ b/src/OOPsIPushedToMain/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ glide = "5.0.0-rc01"
 
 [libraries]
 androidx-espresso-core = { module = "androidx.support.test.espresso:espresso-core", version.ref = "espressoCoreVersion" }
+androidx-espresso-intents = { module = "androidx.test.espresso:espresso-intents", version.ref = "espressoCore" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
The current CI is disabled, this pull request sets the template for the file.
Currently will only test the FirebaseAccess class.
The code was tested on a local copy of the repo, so it should work (maybe)